### PR TITLE
allow specifying another json file in the source + YAML support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,22 @@ Translates markdown files and a structure json file into an importable Open Edx 
 `npm install -g md2oedx`
 
 ## Usage
-`md2oedx ./source/path ./destination/path`
+
+```
+md2oedx ./source/path ./destination/path
+```
 
 The source path should contain a plain structure of markdown files and a json file named **index.json** with the course structure. Defaults to current directory.
+
+or specifying your own json file:
+```
+md2oedx ./source/path/foo.json ./destination/path
+```
+
+or specifying a yaml file:
+```
+md2oedx ./source/path/index.yaml ./destination/path
+```
 
 The output will be written to the destination path. Defaults to current directory.
 

--- a/examples/index.yaml
+++ b/examples/index.yaml
@@ -1,0 +1,17 @@
+---
+course:
+  name: How to Eat Pizza
+  number: PIZZA
+  chapter:
+  - name: Acquiring & Eating Pizza
+    sequential:
+    - name: Acquiring Your Pizza
+      vertical:
+      - name: Acquiring Your Pizza
+        html:
+        - file: lesson1.md
+    - name: Eating Your Pizza
+      vertical:
+      - name: Eating Your Pizza
+        html:
+        - file: lesson2.md

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@oclif/plugin-help": "^2",
     "fs-extra": "^7.0.1",
     "hackmd-to-html": "^1.1.0",
+    "js-yaml": "^3.13.1",
     "klaw-sync": "^6.0.0",
     "ramda": "^0.26.1",
     "targz": "^1.0.1",


### PR DESCRIPTION
1. Allow specifying another json file (rather than always `index.json`):
    ```
    $ md2oedx examples/myschedule.json ./lmdexport
    ```
2. YAML support:
    ```
    $ md2oedx examples/index.yaml ./lmdexport
    ```
NB: just because YAML is more digest to read and maybe less syntax-error prone :
```yaml
---
course:
  name: How to Eat Pizza
  number: PIZZA
  chapter:
  - name: Acquiring & Eating Pizza
    sequential:
    - name: Acquiring Your Pizza
      vertical:
      - name: Acquiring Your Pizza
        html:
        - file: lesson1.md
    - name: Eating Your Pizza
      vertical:
      - name: Eating Your Pizza
        html:
        - file: lesson2.md
```

VS.

```json
{
  "course": {
    "name": "How to Eat Pizza",
    "number": "PIZZA",
    "chapter": [{
      "name": "Acquiring & Eating Pizza",
      "sequential": [
        {
          "name": "Acquiring Your Pizza",
          "vertical": [{
            "name": "Acquiring Your Pizza",
            "html": [{
              "file": "lesson1.md"
            }]
          }]
        },
        {
          "name": "Eating Your Pizza",
          "vertical": [{
            "name": "Eating Your Pizza",
            "html": [{
              "file": "lesson2.md"
            }]
          }]
        }
      ]
    }]
  }
}
```