### PR TITLE
BREAKING! Adds support for deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,38 +29,51 @@ The output will be written to the destination path. Defaults to current director
 ## JSON File Structure
 
 Here is a sample json file that describes a course:
-```
+```json
 {
   "course": {
     "name": "Course Title",
     "number": "CT",
-    "chapter": [{
-        "name": "Module 1",
-        "sequential": [{
-            "name": "Submodule 1",
-            "vertical": [{
+    "chapter": [
+      {
+        "name": "Unit 1",
+        "sequential": [
+          {
+            "name": "Weekday",
+            "vertical": [
+              {
                 "name": "Lesson 1",
-                "html": [{
-                    "file": "markdown1"
-                  }
-                ]
+                "component": [{
+                    "type": "html",
+                    "file": "markdowns/lesson1.md"
+                }]
               },
               {
                 "name": "Lesson 2",
-                "html": [{
-                  "file": "markdown2"
+                "component": [{
+                    "type": "html",
+                    "file": "markdowns/lesson2.md"
                 }]
               }
             ]
           },
           {
-            "name": "Submodule 2",
-            "vertical": []
+            "name": "Weekend",
+            "vertical": [{
+                "name": "Homework",
+                "component": [{
+                    "type": "deliverable",
+                    "display_name": "Homework",
+                    "deliverable_identifier": "assign1",
+                    "deliverable_description": "Your first homework is to do 100 pushups.",
+                    "deliverable_duedate": "2030-10-28"
+                }]
+            }]
           }
         ]
       },
       {
-        "name": "Module 2",
+        "name": "Unit 2",
         "sequential": []
       }
     ]

--- a/examples/index.json
+++ b/examples/index.json
@@ -3,27 +3,44 @@
     "name": "How to Eat Pizza",
     "number": "PIZZA",
     "chapter": [{
-      "name": "Acquiring & Eating Pizza",
-      "sequential": [
-        {
-          "name": "Acquiring Your Pizza",
-          "vertical": [{
-            "name": "Acquiring Your Pizza",
-            "html": [{
+      "name": "Big Data & Pizza",
+      "sequential": [{
+        "name": "Monday Your Pizza",
+        "vertical": [
+          {
+            "name": "[TALK] Welcoming Your Pizza",
+            "component": [{
+              "type": "html",
               "file": "lesson1.md"
             }]
-          }]
-        },
-        {
-          "name": "Eating Your Pizza",
-          "vertical": [{
-            "name": "Eating Your Pizza",
-            "html": [{
-              "file": "lesson2.md"
+          },
+          {
+            "name": "Homework for Your Pizza",
+            "component": [
+              {
+                "type": "deliverable",
+                "display_name": "Blah",
+                "deliverable_identifier": "blah1",
+                "deliverable_description": "Blah, blah, blah."
+              },
+              {
+                "type": "html",
+                "file": "lesson2.md"
+              }
+            ]
+          },
+          {
+            "name": "Homework 2 for Your Burger",
+            "component": [{
+              "type": "deliverable",
+              "display_name": "blah",
+              "deliverable_identifier": "blah2",
+              "deliverable_description": "blah, blah, blah.",
+              "deliverable_duedate": "2030-01-28"
             }]
-          }]
-        }
-      ]
+          }
+        ]
+      }]
     }]
   }
 }


### PR DESCRIPTION
This adds support for deliverables/assignments in the JSON structure. It's a breaking change because it expects the `html` key to now be named `component` and elements of those arrays need to contain a `type` key with either `deliverable` or `html`.